### PR TITLE
Grid points

### DIFF
--- a/pyPRISM/core/Domain.py
+++ b/pyPRISM/core/Domain.py
@@ -95,7 +95,9 @@ class Domain(object):
     
     def build_grid(self):
         '''Construct the Real and Fourier Space grids and transform coefficients'''
-        self.r = np.arange(self._dr,self._dr*(self._length+1),self._dr)
+        
+        # note that the r grid points start from half of dr, not from dr. This improve the accuracy of the discrete sine transform
+        self.r = np.arange(.5 * self._dr, self._dr * (self.length + .5), self._dr)
         self.k = np.arange(self.dk,self.dk*(self._length+1),self.dk)
         self.DST_II_coeffs = 2.0*np.pi *self.r*self._dr 
         self.DST_III_coeffs = self.k * self.dk/(4.0*np.pi*np.pi)

--- a/pyPRISM/core/System.py
+++ b/pyPRISM/core/System.py
@@ -134,7 +134,7 @@ class System:
         tol = 1e-6
         # ensure that the diameters are on the real-space grid
         for i,t,d in self.diameter.diameter:
-            check = np.any(np.abs(self.domain.r - d)<tol)
+            check = np.any(np.abs(int(d /self.domain._dr) - d / self.domain._dr) < tol)
             if not check:
                 warn_text  = 'Diameter for site {} = {} is not a multiple '.format(t,d)
                 warn_text += 'of domain grid spacing dr = {}. '.format(self.domain.dr)
@@ -143,7 +143,7 @@ class System:
 
         # ensure that the sigmas are on the real-space grid
         for i,(t1,t2),s in self.diameter.sigma:
-            check = np.any(np.abs(self.domain.r - s)<tol)
+            check = np.any(np.abs(int(d /self.domain._dr) - d / self.domain._dr) < tol)
             if not check:
                 warn_text  = 'Sigma for pair {}-{} = {} is not a multiple '.format(t1,t2,s)
                 warn_text += 'of domain grid spacing dr = {}. '.format(self.domain.dr)


### PR DESCRIPTION
Originally, the grid points in the real space are at the multiples of dr, i.e

r=(dr, 2dr, 3dr, ...)

Change it to,

r=(0.5dr, 1.5dr, 2.5dr, ...)

This improves the accuracy of the PRISM calculation. Especially for very short-range attraction system, this change alleviate the need to use a extremely find grids.